### PR TITLE
Fix NTU titlepage format

### DIFF
--- a/NTU_patch/config.tex
+++ b/NTU_patch/config.tex
@@ -7,9 +7,11 @@
 
 
 %%%%% Information of your document. | 定義文件資訊 %%%%%
+\def\collegeZh {理學院}
+\def\collegeEn {College of Science}
 \def\deptshort {物理}
-\def\deptZh    {理學院~物理研究所} %(請參考各校規定)
-\def\deptEn    {Department of Physics\\College of Science}
+\def\deptZh    {物理研究所} %(請參考各校規定)
+\def\deptEn    {Department of Physics}
 \def\degreeZh  {碩士} % 碩士/博士
 \def\degreeEn  {Master} % Master/博士 | Master thesis/Doctoral dissertation
 \def\titleZh   {臺灣大學LaTeX論文樣板(中文)}   % Chinese title

--- a/NTU_patch/titlepage.tex
+++ b/NTU_patch/titlepage.tex
@@ -71,11 +71,12 @@
 \begin{titlepage}
 %     \null\vfill
     \begin{center}
-        {\fsUniversityZh\textbf{國立臺灣大學~\deptZh} \par
+        {\fsUniversityZh\textbf{國立臺灣大學\collegeZh\deptZh} \par
             \textbf{\degreeZh 論文} \par}
         \vspace*{5mm}
         
         {\fsDeptEn \deptEn \par}
+        {\fsDeptEn \collegeEn \par}
         {\fsUniversityEn 
             National Taiwan University \par
             \degreeEn\ Thesis\par}


### PR DESCRIPTION
According to the latest official thesis format [1]
- There are no spaces between school, college and department names
- College name in english is also need to be included

Reference:
[1] http://www.lib.ntu.edu.tw/doc/cl/THESISSAMPLE.doc